### PR TITLE
Zenity dialogs and symbolic papirus icons

### DIFF
--- a/optimus-manager-ar.sh
+++ b/optimus-manager-ar.sh
@@ -6,36 +6,49 @@ notify_switch="notify-send -h int:transient:2 -i \\\"dialog-information-symbolic
 notify_reboot="notify-send -h int:transient:2 -i \\\"dialog-information-symbolic\\\"  \\\"Optimus Manager Indicator\\\" \\\"System will reboot! \\\" ; "
 
 activate_intel="\"\
+	if zenity --question --title \\\"Optimus Manager Indicator\\\" --text \\\"Restart X server to switch on Intel?\\\" --width=256; \
+	then \
 	$notify_switch \
 	sleep 2; \
-	$intel_switch \
+	$intel_switch; \
+	else \
+	exit 1; \
+	fi \
 	\""
 
 activate_nvidia="\"\
+	if zenity --question --title \\\"Optimus Manager Indicator\\\" --text \\\"Restart X server to switch on Nvidia?\\\" --width=256; \
+	then \
 	$notify_switch \
 	sleep 2; \
-	$nvidia_switch \
+	$nvidia_switch; \
+	else \
+	exit 1; \
+	fi \
 	\""
 
 reboot_cmd="\"\
+	if zenity --question --title \\\"Optimus Manager Indicator\\\" --text \\\"Reboot your system?\\\" --width=160; \
+	then \
 	$notify_reboot \
 	sleep 1; \
-	systemctl --no-wall reboot \
+	systemctl --no-wall reboot; \
+	else \
+	exit 1; \
+	fi \
 	\""
 
 nvidia_settings="\"nvidia-settings -p 'PRIME Profiles'\""
-nvidia_active_icon="nvidiaactivesymbolic"
-nvidia_inactive_icon="primeindicatorintelsymbolic"
-reboot_icon="'system-restart'"
+reboot_icon="'system-reboot-symbolic'"
 
 
 QUERY=$(optimus-manager --print-mode)
 if [ "$QUERY" == 'Current mode : nvidia' ]; then
-    nvidia_state_icon=$nvidia_active_icon
+    nvidia_state_icon=prime-nvidia
     TEMP=$(nvidia-smi -q -d TEMPERATURE | grep 'GPU Current Temp' | awk '{print $5}')
     panel_string="$TEMP\xe2\x84\x83 | "
 else
-    nvidia_state_icon=$nvidia_inactive_icon
+    nvidia_state_icon=prime-intel
     panel_string=" | "
 fi
 
@@ -43,8 +56,8 @@ echo -e "$panel_string""iconName=$nvidia_state_icon"
 echo "---"
 echo "NVIDIA PRIME Profiles| iconName=$nvidia_state_icon bash=$nvidia_settings terminal=false"
 echo "---"
-echo "Switch to INTEL | iconName='primeindicatorintel' bash=$activate_intel terminal=false"
-echo "Switch to NVIDIA  | iconName='primeindicatornvidia' bash=$activate_nvidia  terminal=false"
+echo "Switch to INTEL | iconName='prime-intel' bash=$activate_intel terminal=false"
+echo "Switch to NVIDIA  | iconName='prime-nvidia' bash=$activate_nvidia  terminal=false"
 
 echo "---"
 echo "System Reboot | iconName=$reboot_icon bash=$reboot_cmd terminal=false"


### PR DESCRIPTION
* Added [zenity](https://www.archlinux.org/packages/extra/x86_64/zenity/) dialogs with questions to avoid accidental switching.
* Icons changed to symbolic: `prime-nvidia` and `prime-intel`. Working well with [papirus-icon-theme](https://www.archlinux.org/packages/community/any/papirus-icon-theme/).