### PR TITLE
Correctly read current mode for optimus-manager >= v1.0

### DIFF
--- a/optimus-manager-ar.sh
+++ b/optimus-manager-ar.sh
@@ -42,8 +42,8 @@ nvidia_settings="\"nvidia-settings -p 'PRIME Profiles'\""
 reboot_icon="'system-reboot-symbolic'"
 
 
-QUERY=$(optimus-manager --print-mode)
-if [ "$QUERY" == 'Current mode : nvidia' ]; then
+QUERY=$(optimus-manager --print-mode | grep 'Current GPU mode' | awk '{print $5}')
+if [ "$QUERY" == 'nvidia' ]; then
     nvidia_state_icon=prime-nvidia
     TEMP=$(nvidia-smi -q -d TEMPERATURE | grep 'GPU Current Temp' | awk '{print $5}')
     panel_string="$TEMP\xe2\x84\x83 | "


### PR DESCRIPTION
From optimus-manager v1.0 output of --print-mode changed. Current version of optimus-manager-argos will always show intel. This patch fixes this behavior.