### PR TITLE
Adding "Hybrid" mode

### DIFF
--- a/icons/primeindicatorhybridsymbolic.svg
+++ b/icons/primeindicatorhybridsymbolic.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="310.00189"
+   height="310.00189"
+   version="1"
+   id="svg2"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="primeindicatorhybridsymbolic.svg"
+   inkscape:export-filename="/home/andre/git/prime-indicator/resource/intel.svg.png"
+   inkscape:export-xdpi="38.249958"
+   inkscape:export-ydpi="38.249958">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 1.4711357,311.14608 311.22099,1.3962375 c 0,103.2499425 0,206.4998925 0,309.7498425 z"
+         id="path24"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path26"
+         d="M 0,310.90233 309.74985,1.1524816 0.90043953,0.25204833 Z"
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0,310.90233 309.74985,1.1524816 0.90043953,0.25204833 Z"
+         id="path45"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4632">
+      <rect
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         y="0.42809963"
+         x="0.42620242"
+         height="309.14758"
+         width="154.1476"
+         id="rect4634" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4636">
+      <rect
+         id="rect4638"
+         width="154.1476"
+         height="309.14758"
+         x="0.42620242"
+         y="0.42809963"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <rect
+         id="rect49"
+         width="154.1476"
+         height="309.14758"
+         x="155.42599"
+         y="0.42641699"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="0.5552868"
+     inkscape:cx="207.09166"
+     inkscape:cy="226.16348"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-top="55.00083"
+     fit-margin-bottom="55.00083" />
+  <path
+     d="M 303.68264,111.80119 C 289.55664,42.408188 156.32064,38.013188 70.432641,90.881188 l 0,5.84 c 85.773999,-44.62 207.479999,-44.334 218.555999,19.588002 3.732,21.176 -8.022,43.2 -29.097,55.872 l 0,16.584 c 25.37,-9.38 51.304,-39.744 43.792,-76.964 m -156.179,121.497 c -59.269999,5.53 -121.029999,-3.173 -129.675999,-50.033 -4.293,-23.075 6.16,-47.565 19.947,-62.76 l 0,-8.136 c -24.862,22.054 -38.36699986,49.95 -30.5699998,82.886 9.9449998,42.267 62.9459998,66.192 143.8599988,58.226 32.037,-3.117 73.964,-13.55 103.06,-29.733 l 0,-22.992 c -26.442,15.958 -70.177,29.143 -106.62,32.542 z"
+     id="path4"
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     clip-path="url(#clipPath4636)" />
+  <path
+     d="m 249.38064,101.77119 -15.54,0 0,70.05 c 0,8.228 3.9,15.384 15.54,16.52 m -185.104999,-60.97 -15.54,0 0,45.755 c 0,8.23 3.9,15.383 15.54,16.517 m -15.539,-85.745 15.54,0 0,14.903 -15.54,0 z m 108.653999,85.009 c -12.598,0 -17.91,-8.857 -17.91,-17.598 l 0,-60.77 15.37,0 0,16.832 11.638,0 0,12.602 -11.638,0 0,30.4 c 0,3.574 1.695,5.535 5.366,5.535 l 6.272,0 0,13 -9.097,0 m 40.852,-49.7 c -5.253,0 -9.32,2.752 -11.016,6.47 -1.017,2.243 -1.357,3.946 -1.524,6.7 l 23.787,0 c -0.34,-6.727 -3.336,-13.17 -11.247,-13.17 m -12.54,23.786 c 0,7.976 4.97,13.848 13.67,13.848 6.84,0 10.23,-1.93 14.185,-5.87 l 9.493,9.223 c -6.102,6.072 -12.487,9.763 -23.787,9.763 -14.747,0 -28.874,-8.146 -28.874,-31.875 0,-20.292 12.316,-31.76 28.533,-31.76 16.443,0 25.877,13.426 25.877,31.053 l 0,5.62 -39.097,0 m -79.559,-23.023 c 4.52,0 6.385,2.243 6.385,5.904 l 0,43.115 15.425,0 0,-43.17 c 0,-8.77 -4.634,-18.45 -18.138,-18.45 l -31.809999,0 0,61.62 15.367,0 0,-49.018"
+     id="path6"
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     clip-path="url(#clipPath4632)" />
+  <path
+     transform="translate(5.1269531e-6,0.00189209)"
+     d="m 35.652,141.098 c 0,0 27.123,-40.32 81.28,-44.49 V 81.98 C 56.945,86.834 5,138.02 5,138.02 c 0,0 29.422,85.69 111.932,93.535 v -15.548 c -60.55,-7.675 -81.28,-74.91 -81.28,-74.91 z m 81.28,43.987 v 14.24 c -45.762,-8.22 -58.465,-56.147 -58.465,-56.147 0,0 21.972,-24.524 58.465,-28.5 v 15.624 c -0.025,0 -0.045,-0.008 -0.07,-0.008 -19.15,-2.316 -34.114,15.71 -34.114,15.71 0,0 8.387,30.35 34.186,39.08 m 0,-130.084 v 26.98 c 1.762,-0.135 3.523,-0.25 5.294,-0.31 68.2,-2.317 112.634,56.35 112.634,56.35 0,0 -51.036,62.524 -104.21,62.524 -4.87,0 -9.432,-0.456 -13.72,-1.22 v 16.683 c 3.667,0.47 7.467,0.745 11.43,0.745 49.48,0 85.26,-25.46 119.91,-55.59 5.743,4.635 29.26,15.91 34.096,20.847 -32.944,27.787 -109.72,50.187 -153.247,50.187 -4.195,0 -8.224,-0.257 -12.185,-0.64 V 255 H 305 V 55 H 116.93 Z m 0,59.678 V 96.61 c 1.744,-0.123 3.5,-0.218 5.294,-0.275 49.04,-1.552 81.216,42.46 81.216,42.46 0,0 -34.752,48.624 -72.012,48.624 -5.363,0 -10.17,-0.87 -14.498,-2.335 v -54.781 c 19.092,2.324 22.935,10.82 34.413,30.097 l 25.528,-21.686 c 0,0 -18.635,-24.624 -50.048,-24.624 -3.415,0 -6.682,0.24 -9.89,0.588"
+     id="path4-6"
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     clip-path="url(#clipPath47)" />
+</svg>

--- a/optimus-manager-ar.sh
+++ b/optimus-manager-ar.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Thanks for idea and base script cyberalex4life <3 
 nvidia_switch="optimus-manager --no-confirm --switch nvidia"
+hybrid_switch="optimus-manager --no-confirm --switch hybrid"
 intel_switch="optimus-manager --no-confirm --switch intel"
 notify_switch="notify-send -h int:transient:2 -i \\\"dialog-information-symbolic\\\" \\\"Optimus Manager Indicator\\\" \\\"Switching graphics and restaring X server to finalize process! \\\" ; "
 activate_intel="\"\
@@ -9,6 +10,17 @@ activate_intel="\"\
 	$notify_switch \
 	sleep 2; \
 	$intel_switch; \
+	else \
+	exit 1; \
+	fi \
+	\""
+
+activate_hybrid="\"\
+	if zenity --question --title \\\"Optimus Manager Indicator\\\" --text \\\"Restart X server to switch on Hybrid?\\\" --width=256; \
+	then \
+	$notify_switch \
+	sleep 2; \
+	$hybrid_switch; \
 	else \
 	exit 1; \
 	fi \
@@ -29,8 +41,12 @@ nvidia_settings="\"nvidia-settings -p 'PRIME Profiles'\""
 
 
 QUERY=$(optimus-manager --print-mode | grep 'Current GPU mode' | awk '{print $5}')
-if [ "$QUERY" == 'nvidia' ]; then
-    nvidia_state_icon=primeindicatornvidiasymbolic
+if [ "$QUERY" == 'nvidia' ] || [ "$QUERY" == 'hybrid' ]; then
+	if [ "$QUERY" == 'nvidia' ]; then
+		nvidia_state_icon=primeindicatornvidiasymbolic
+	else
+		nvidia_state_icon=primeindicatorhybridsymbolic
+	fi
     TEMP=$(nvidia-smi -q -d TEMPERATURE | grep 'GPU Current Temp' | awk '{print $5}')
     panel_string="$TEMP\xe2\x84\x83 | "
 else
@@ -43,4 +59,5 @@ echo "---"
 echo "NVIDIA PRIME Profiles | iconName=$nvidia_state_icon bash=$nvidia_settings terminal=false"
 echo "---"
 echo "Switch to INTEL | iconName='primeindicatorintelsymbolic' bash=$activate_intel terminal=false"
+echo "Switch to HYBRID  | iconName='primeindicatorhybridsymbolic' bash=$activate_hybrid  terminal=false"
 echo "Switch to NVIDIA  | iconName='primeindicatornvidiasymbolic' bash=$activate_nvidia  terminal=false"


### PR DESCRIPTION
Optimus-manager 1.2 introduced a new "hybrid" mode that let users with the latest Turing generations graphics cards and Coffee Lake processors use the latest NVIDIA driver that introduces power management and PRIME Offloading.

This pull request adds a button to switch to hybrid mode and an icon which is a mix between the Intel and NVIDIA icon. Hybrid mode should also show the GPU temperature like in the NVIDIA mode.

I wasn't able to test it because optimus-manager doesn't report the correct mode on my side. It should work anyway according to optimus-manager developer(s).