### PR TITLE
Adding parameters and configuration file to select the displayed data

### DIFF
--- a/optimus-manager-ar.1s.sh
+++ b/optimus-manager-ar.1s.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Thanks for idea and base script cyberalex4life <3 
+
+# You can set parameters in this file
+source ~/.config/optimus-manager-argos/omarc 2> /dev/null
+
 nvidia_switch="optimus-manager --no-confirm --switch nvidia"
 hybrid_switch="optimus-manager --no-confirm --switch hybrid"
 intel_switch="optimus-manager --no-confirm --switch intel"
@@ -47,8 +51,31 @@ if [ "$QUERY" == 'nvidia' ] || [ "$QUERY" == 'hybrid' ]; then
 	else
 		nvidia_state_icon=primeindicatorhybridsymbolic
 	fi
-    TEMP=$(nvidia-smi -q -d TEMPERATURE | grep 'GPU Current Temp' | awk '{print $5}')
-    panel_string="$TEMP\xe2\x84\x83 | "
+
+	MULTIPLE_DATA=false
+	_OPTIMUS_MANAGER_ARGOS_SHOW_TEMP=${_OPTIMUS_MANAGER_ARGOS_SHOW_TEMP:-1}
+	_OPTIMUS_MANAGER_ARGOS_SHOW_POWER=${_OPTIMUS_MANAGER_ARGOS_SHOW_POWER:-0}
+	panel_string = ""
+
+	if [ "$_OPTIMUS_MANAGER_ARGOS_SHOW_TEMP" != '0' ]; then
+		TEMP=$(nvidia-smi -q -d TEMPERATURE | grep 'GPU Current Temp' | awk '{print $5}')
+		if [ "$MULTIPLE_DATA" == true ]; then
+			panel_string="$panel_string -"
+		fi
+		panel_string="$panel_string $TEMP\xe2\x84\x83"
+		MULTIPLE_DATA=true
+	fi
+	
+	if [ "$_OPTIMUS_MANAGER_ARGOS_SHOW_POWER" != '0' ]; then
+		POWER=$(nvidia-smi -q -d POWER | grep 'Power Draw' | awk '{print $4}')
+		if [ "$MULTIPLE_DATA" == true ]; then
+			panel_string="$panel_string -"
+		fi
+		panel_string="$panel_string $POWER\x57"
+		MULTIPLE_DATA=true
+	fi
+
+	panel_string="$panel_string | "
 else
     nvidia_state_icon=primeindicatorintelsymbolic
     panel_string=""


### PR DESCRIPTION
By default, it is showing only the temperature (to keep the default behaviour from
current version). The parameters are environment variables that must be stored
in ~/.config/optimus-manager-argos/omarc.

This commit introduces 2 parameters :
* `_OPTIMUS_MANAGER_ARGOS_SHOW_POWER` : default to 0, shows the power consumption
* `_OPTIMUS_MANAGER_ARGOS_SHOW_TEMP` : default to 1, shows the temperature

Set them by adding the command `export <variable>=<value>` in the configuration
file (~/.config/optimus-manager-argos/omarc)